### PR TITLE
fix: サークルメンバー情報の取得を読み込み完了後にもするように修正

### DIFF
--- a/components/layouts/circle-detail-page.tsx
+++ b/components/layouts/circle-detail-page.tsx
@@ -1,7 +1,15 @@
 "use client"
 
 import type { FC } from "@yamada-ui/react"
-import { Box, Heading, HStack, Tag, Text, VStack } from "@yamada-ui/react"
+import {
+  Box,
+  Heading,
+  HStack,
+  Tag,
+  Text,
+  useSafeLayoutEffect,
+  VStack,
+} from "@yamada-ui/react"
 import { useState } from "react"
 import { CircleDetailTabs } from "../disclosure/circle-detail-tabs"
 import { CircleDetailButton } from "../forms/circle-detail-button"
@@ -43,6 +51,10 @@ export const CircleDetailPage: FC<{
       setRequests(await getMembershipRequests(userId, circle.id))
     }
   }
+
+  useSafeLayoutEffect(() => {
+    fetchData()
+  }, [])
 
   const isMember = circle?.members?.some((member) => member.id === userId)
   // ユーザーがサークルの管理者かどうかを確認


### PR DESCRIPTION
Closes # <!-- 関連するイシュー番号があれば書く（例：#0） -->

## 概要

<!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->

## 変更点

反映前はサークルメンバー情報を編集した時に（メンバー権限変更・入会退会）メンバー情報は反映されるが、タブを切り替えてメンバー一覧のタブに戻ると何故か変更前の状態になっていてページをリロードしないと反映されない。
これを反映されるように修正した。

## 追加情報

<!-- その他で記述する情報があれば書いてください -->
