### PR TITLE
fix: 活動日一覧のモバイル時のスタイル修正

### DIFF
--- a/components/data-display/activity-card.tsx
+++ b/components/data-display/activity-card.tsx
@@ -59,13 +59,13 @@ export const ActivityCard: FC<ActivityCardProps> = ({
               handleDelete={handleDelete}
             />
           </HStack>
-          <HStack flexDir="row" flexWrap="wrap" alignItems={{ md: "start" }}>
+          <HStack flexWrap="wrap" alignItems={{ md: "start" }}>
             <Text whiteSpace="nowrap">内容:</Text>
             <Text text-wrap="auto" whiteSpace="pre-wrap">
               {currentActivity.description}
             </Text>
           </HStack>
-          <HStack flexDir="row" flexWrap="wrap" alignItems={{ md: "start" }}>
+          <HStack flexWrap="wrap" alignItems={{ md: "start" }}>
             <Text>活動時間:</Text>
             <Text>
               {displayTime(currentActivity.startTime)}
@@ -74,15 +74,15 @@ export const ActivityCard: FC<ActivityCardProps> = ({
                 : undefined}
             </Text>
           </HStack>
-          <HStack flexDir="row" flexWrap="wrap" alignItems={{ md: "start" }}>
+          <HStack flexWrap="wrap" alignItems={{ md: "start" }}>
             <Text>活動場所:</Text>
             <Text>{currentActivity.location}</Text>
           </HStack>
-          <HStack flexDir="row" flexWrap="wrap" alignItems={{ md: "start" }}>
+          <HStack flexWrap="wrap" alignItems={{ md: "start" }}>
             <Text>参加人数:</Text>
             <Text>{currentActivity.participants.length}人</Text>
           </HStack>
-          <HStack flexDir="row" flexWrap="wrap" alignItems={{ md: "start" }}>
+          <HStack flexWrap="wrap" alignItems={{ md: "start" }}>
             <Text whiteSpace="nowrap">備考:</Text>
             <Text text-wrap="auto" whiteSpace="pre-wrap">
               {currentActivity.notes}

--- a/components/data-display/activity-card.tsx
+++ b/components/data-display/activity-card.tsx
@@ -59,19 +59,13 @@ export const ActivityCard: FC<ActivityCardProps> = ({
               handleDelete={handleDelete}
             />
           </HStack>
-          <HStack
-            flexDir={{ base: "row", md: "column" }}
-            alignItems={{ md: "start" }}
-          >
+          <HStack flexDir="row" flexWrap="wrap" alignItems={{ md: "start" }}>
             <Text whiteSpace="nowrap">内容:</Text>
             <Text text-wrap="auto" whiteSpace="pre-wrap">
               {currentActivity.description}
             </Text>
           </HStack>
-          <HStack
-            flexDir={{ base: "row", md: "column" }}
-            alignItems={{ md: "start" }}
-          >
+          <HStack flexDir="row" flexWrap="wrap" alignItems={{ md: "start" }}>
             <Text>活動時間:</Text>
             <Text>
               {displayTime(currentActivity.startTime)}
@@ -80,24 +74,15 @@ export const ActivityCard: FC<ActivityCardProps> = ({
                 : undefined}
             </Text>
           </HStack>
-          <HStack
-            flexDir={{ base: "row", md: "column" }}
-            alignItems={{ md: "start" }}
-          >
+          <HStack flexDir="row" flexWrap="wrap" alignItems={{ md: "start" }}>
             <Text>活動場所:</Text>
             <Text>{currentActivity.location}</Text>
           </HStack>
-          <HStack
-            flexDir={{ base: "row", md: "column" }}
-            alignItems={{ md: "start" }}
-          >
+          <HStack flexDir="row" flexWrap="wrap" alignItems={{ md: "start" }}>
             <Text>参加人数:</Text>
             <Text>{currentActivity.participants.length}人</Text>
           </HStack>
-          <HStack
-            flexDir={{ base: "row", md: "column" }}
-            alignItems={{ md: "start" }}
-          >
+          <HStack flexDir="row" flexWrap="wrap" alignItems={{ md: "start" }}>
             <Text whiteSpace="nowrap">備考:</Text>
             <Text text-wrap="auto" whiteSpace="pre-wrap">
               {currentActivity.notes}

--- a/components/data-display/circle-activitydays.tsx
+++ b/components/data-display/circle-activitydays.tsx
@@ -231,25 +231,24 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
                             </Box>
                           </LinkOverlay>
                           <HStack
-                            flexDir={{ base: "row", md: "column" }}
                             w={{ md: "full" }}
+                            flexWrap="wrap"
+                            justifyContent={{ base: "center", md: "start" }}
                           >
-                            <Text mr={{ md: "auto" }} lineClamp={1}>
-                              {activity.location}
-                            </Text>
-                            <Text mr={{ md: "auto" }}>
+                            <Text lineClamp={1}>{activity.location}</Text>
+                            <Text>
                               {displayTime(activity.startTime)}
                               {activity.endTime
                                 ? `～${displayTime(activity.endTime)}`
                                 : undefined}
                             </Text>
-                            <Text mr={{ md: "auto" }} whiteSpace="nowrap">
+                            <Text
+                              whiteSpace="nowrap"
+                              display={{ base: "inline", md: "none" }}
+                            >
                               {activity.participants.length}人
                             </Text>
-                            <Box
-                              ml={{ md: "auto" }}
-                              display={{ base: "block", md: "none" }}
-                            >
+                            <Box display={{ base: "block", md: "none" }}>
                               <ActivityMenuButton
                                 userId={userId}
                                 isMember={!!isMember}

--- a/components/data-display/circle-activitydays.tsx
+++ b/components/data-display/circle-activitydays.tsx
@@ -181,75 +181,86 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
                 <GridItem key={activity.id}>
                   <Card variant="outline" as={LinkBox} bg="white">
                     <CardBody>
-                      <HStack
-                        justifyContent="space-between"
-                        w="full"
-                        flexDir={{ base: "row", md: "column" }}
-                      >
-                        <LinkOverlay
-                          justifyContent={{ base: "center", md: "start" }}
-                          alignItems="center"
-                          gap="md"
-                          as={Link}
-                          display="flex"
-                          href={`/circles/${circle?.id}/activities/${activity.id}`}
-                          w={{ md: "full" }}
+                      <HStack alignItems="start" w="full">
+                        <Card
+                          variant="outline"
+                          padding="sm"
+                          w="10"
+                          as={Center}
+                          display={{ base: "none", md: "flex" }}
                         >
-                          <Card
-                            variant="outline"
-                            padding="sm"
-                            w="10"
-                            as={Center}
-                          >
-                            {activity.activityDay.getDate()}
-                          </Card>
-                          <Text lineClamp={1}>{activity.title}</Text>
-                          <Box
-                            display={{ base: "none", md: "block" }}
-                            ml="auto"
-                          >
-                            <ActivityMenuButton
-                              userId={userId}
-                              isMember={!!isMember}
-                              isAdmin={!!isAdmin}
-                              circle={circle}
-                              activity={activity}
-                              handleParticipation={handleParticipation}
-                              handleDelete={handleDelete}
-                            />
-                          </Box>
-                        </LinkOverlay>
-
+                          {activity.activityDay.getDate()}
+                        </Card>
                         <HStack
+                          justifyContent="space-between"
+                          w="full"
                           flexDir={{ base: "row", md: "column" }}
-                          w={{ md: "full" }}
                         >
-                          <Text mr={{ md: "auto" }} lineClamp={1}>
-                            {activity.location}
-                          </Text>
-                          <Text mr={{ md: "auto" }}>
-                            {displayTime(activity.startTime)}
-                            {activity.endTime
-                              ? `～${displayTime(activity.endTime)}`
-                              : undefined}
-                          </Text>
-                          <Text mr={{ md: "auto" }} whiteSpace="nowrap">
-                            {activity.participants.length}人
-                          </Text>
-                          <Box
-                            ml={{ md: "auto" }}
-                            display={{ base: "block", md: "none" }}
+                          <LinkOverlay
+                            justifyContent={{ base: "center", md: "start" }}
+                            alignItems="center"
+                            gap="md"
+                            as={Link}
+                            display="flex"
+                            href={`/circles/${circle?.id}/activities/${activity.id}`}
+                            w={{ md: "full" }}
                           >
-                            <ActivityMenuButton
-                              userId={userId}
-                              isMember={!!isMember}
-                              isAdmin={!!isAdmin}
-                              circle={circle}
-                              activity={activity}
-                              handleParticipation={handleParticipation}
-                              handleDelete={handleDelete}
-                            />
-                          </Box>
+                            <Card
+                              variant="outline"
+                              padding="sm"
+                              w="10"
+                              as={Center}
+                              display={{ base: "flex", md: "none" }}
+                            >
+                              {activity.activityDay.getDate()}
+                            </Card>
+                            <Text lineClamp={1}>{activity.title}</Text>
+                            <Box
+                              display={{ base: "none", md: "block" }}
+                              ml="auto"
+                            >
+                              <ActivityMenuButton
+                                userId={userId}
+                                isMember={!!isMember}
+                                isAdmin={!!isAdmin}
+                                circle={circle}
+                                activity={activity}
+                                handleParticipation={handleParticipation}
+                                handleDelete={handleDelete}
+                              />
+                            </Box>
+                          </LinkOverlay>
+                          <HStack
+                            flexDir={{ base: "row", md: "column" }}
+                            w={{ md: "full" }}
+                          >
+                            <Text mr={{ md: "auto" }} lineClamp={1}>
+                              {activity.location}
+                            </Text>
+                            <Text mr={{ md: "auto" }}>
+                              {displayTime(activity.startTime)}
+                              {activity.endTime
+                                ? `～${displayTime(activity.endTime)}`
+                                : undefined}
+                            </Text>
+                            <Text mr={{ md: "auto" }} whiteSpace="nowrap">
+                              {activity.participants.length}人
+                            </Text>
+                            <Box
+                              ml={{ md: "auto" }}
+                              display={{ base: "block", md: "none" }}
+                            >
+                              <ActivityMenuButton
+                                userId={userId}
+                                isMember={!!isMember}
+                                isAdmin={!!isAdmin}
+                                circle={circle}
+                                activity={activity}
+                                handleParticipation={handleParticipation}
+                                handleDelete={handleDelete}
+                              />
+                            </Box>
+                          </HStack>
                         </HStack>
                       </HStack>
                     </CardBody>

--- a/components/data-display/circle-activitydays.tsx
+++ b/components/data-display/circle-activitydays.tsx
@@ -3,6 +3,7 @@ import { MonthPicker } from "@yamada-ui/calendar"
 import { ChevronLeftIcon, ChevronRightIcon } from "@yamada-ui/lucide"
 import type { FC } from "@yamada-ui/react"
 import {
+  Box,
   Card,
   CardBody,
   Center,
@@ -180,14 +181,19 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
                 <GridItem key={activity.id}>
                   <Card variant="outline" as={LinkBox} bg="white">
                     <CardBody>
-                      <HStack justifyContent="space-between" w="full">
+                      <HStack
+                        justifyContent="space-between"
+                        w="full"
+                        flexDir={{ base: "row", md: "column" }}
+                      >
                         <LinkOverlay
-                          justifyContent="center"
+                          justifyContent={{ base: "center", md: "start" }}
                           alignItems="center"
                           gap="md"
                           as={Link}
                           display="flex"
                           href={`/circles/${circle?.id}/activities/${activity.id}`}
+                          w={{ md: "full" }}
                         >
                           <Card
                             variant="outline"
@@ -198,28 +204,52 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
                             {activity.activityDay.getDate()}
                           </Card>
                           <Text lineClamp={1}>{activity.title}</Text>
+                          <Box
+                            display={{ base: "none", md: "block" }}
+                            ml="auto"
+                          >
+                            <ActivityMenuButton
+                              userId={userId}
+                              isMember={!!isMember}
+                              isAdmin={!!isAdmin}
+                              circle={circle}
+                              activity={activity}
+                              handleParticipation={handleParticipation}
+                              handleDelete={handleDelete}
+                            />
+                          </Box>
                         </LinkOverlay>
 
-                        <HStack>
-                          <Text lineClamp={1}>{activity.location}</Text>
-                          <Text>
+                        <HStack
+                          flexDir={{ base: "row", md: "column" }}
+                          w={{ md: "full" }}
+                        >
+                          <Text mr={{ md: "auto" }} lineClamp={1}>
+                            {activity.location}
+                          </Text>
+                          <Text mr={{ md: "auto" }}>
                             {displayTime(activity.startTime)}
                             {activity.endTime
                               ? `～${displayTime(activity.endTime)}`
                               : undefined}
                           </Text>
-                          <Text whiteSpace="nowrap">
+                          <Text mr={{ md: "auto" }} whiteSpace="nowrap">
                             {activity.participants.length}人
                           </Text>
-                          <ActivityMenuButton
-                            userId={userId}
-                            isMember={!!isMember}
-                            isAdmin={!!isAdmin}
-                            circle={circle}
-                            activity={activity}
-                            handleParticipation={handleParticipation}
-                            handleDelete={handleDelete}
-                          />
+                          <Box
+                            ml={{ md: "auto" }}
+                            display={{ base: "block", md: "none" }}
+                          >
+                            <ActivityMenuButton
+                              userId={userId}
+                              isMember={!!isMember}
+                              isAdmin={!!isAdmin}
+                              circle={circle}
+                              activity={activity}
+                              handleParticipation={handleParticipation}
+                              handleDelete={handleDelete}
+                            />
+                          </Box>
                         </HStack>
                       </HStack>
                     </CardBody>

--- a/components/forms/activity-menu-button.tsx
+++ b/components/forms/activity-menu-button.tsx
@@ -104,6 +104,7 @@ export const ActivityMenuButton: FC<ActivityMenuButtonProps> = ({
       (participant) => participant.userId === userId,
     ) ? (
     <Button
+      // ml={{md: "auto"}}
       colorScheme="riverBlue"
       onClick={() => handleParticipation(activity.id)}
     >
@@ -111,6 +112,7 @@ export const ActivityMenuButton: FC<ActivityMenuButtonProps> = ({
     </Button>
   ) : (
     <Button
+      // ml={{md: "auto"}}
       colorScheme="riverBlue"
       onClick={() => handleParticipation(activity.id)}
     >


### PR DESCRIPTION
Related #192 <!-- 関連するイシュー番号があれば書く（例：#0） -->

## 概要

<img width="212" alt="image" src="https://github.com/user-attachments/assets/120205f3-86e0-4fd8-8740-657136e690f9">

## 変更点

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

## 追加情報

<!-- その他で記述する情報があれば書いてください -->
