### PR TITLE
[バグ] - アルバム作成画面で画像を削除ボタンの位置調整

### DIFF
--- a/components/data-display/album-preview-grid.tsx
+++ b/components/data-display/album-preview-grid.tsx
@@ -12,11 +12,11 @@ export const AlbumPreviewGrid: FC<{
     gap="md"
     overflow="auto"
     pt="sm"
-    width={{base:"600px",md:"100%"}}
+    width={{ base: "3xl", md: "full" }}
     alignItems="center"
   >
     {images.map((src, index) => (
-      <GridItem key={index} boxSize="100px" position="relative" rounded="md">
+      <GridItem key={index} boxSize="4xs" position="relative" rounded="md">
         <Image
           src={src}
           alt={`preview-${index}`}

--- a/components/data-display/album-preview-grid.tsx
+++ b/components/data-display/album-preview-grid.tsx
@@ -12,6 +12,8 @@ export const AlbumPreviewGrid: FC<{
     gap="md"
     overflow="auto"
     pt="sm"
+    width={{base:"600px",md:"100%"}}
+    alignItems="center"
   >
     {images.map((src, index) => (
       <GridItem key={index} boxSize="100px" position="relative" rounded="md">


### PR DESCRIPTION
Closes #182 <!-- 関連するイシュー番号があれば書く（例：#0） -->

## 概要

<!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->

## 変更点

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->
アルバム作成・編集画面で５枚以上の画像をアップロードしたとき、一番右の画像の削除ボタンが見切れる症状の修正
## 追加情報

<!-- その他で記述する情報があれば書いてください -->
