### PR TITLE
fix: サークルメンバーのみ追加・作成ボタンを表示するように変更

### DIFF
--- a/components/data-display/circle-activitydays.tsx
+++ b/components/data-display/circle-activitydays.tsx
@@ -198,9 +198,9 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
               href={`/circles/${circle?.id}/activities/new`}
               startIcon={<PlusIcon fontSize="2xl" />}
               colorScheme="riverBlue"
-            >
-              追加
-            </Button>
+              >
+                追加
+              </Button>
             )}
           </HStack>
           <VStack w="full" h="full">

--- a/components/data-display/circle-activitydays.tsx
+++ b/components/data-display/circle-activitydays.tsx
@@ -192,7 +192,8 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
                 />
               </HStack>
             </HStack>
-            <Button
+            {isMember && (
+              <Button
               as={Link}
               href={`/circles/${circle?.id}/activities/new`}
               startIcon={<PlusIcon fontSize="2xl" />}
@@ -200,6 +201,7 @@ export const CircleActivitydays: FC<CircleActivitydays> = ({
             >
               追加
             </Button>
+            )}
           </HStack>
           <VStack w="full" h="full">
             {loading ? (

--- a/components/data-display/circle-albums.tsx
+++ b/components/data-display/circle-albums.tsx
@@ -90,16 +90,16 @@ export const CircleAlbums: FC<CircleAlbums> = ({
   return (
     <VStack w="full" h="full">
       {isMember && (
-      <HStack justifyContent="end">
-        <Button
-          as={Link}
-          href={`/circles/${circleId}/album/create`}
-          startIcon={<PlusIcon fontSize="2xl" />}
-          colorScheme="riverBlue"
-        >
-          作成
-        </Button>
-      </HStack>
+        <HStack justifyContent="end">
+          <Button
+            as={Link}
+            href={`/circles/${circleId}/album/create`}
+            startIcon={<PlusIcon fontSize="2xl" />}
+            colorScheme="riverBlue"
+          >
+            作成
+          </Button>
+        </HStack>
       )}
       <Snacks snacks={snacks} />
       {currentAlbum ? (

--- a/components/data-display/circle-albums.tsx
+++ b/components/data-display/circle-albums.tsx
@@ -53,6 +53,7 @@ interface CircleAlbums {
 export const CircleAlbums: FC<CircleAlbums> = ({
   userId,
   circleId,
+  isMember,
   isAdmin,
   currentAlbum: album,
 }) => {
@@ -88,6 +89,7 @@ export const CircleAlbums: FC<CircleAlbums> = ({
   }, [])
   return (
     <VStack w="full" h="full">
+      {isMember && (
       <HStack justifyContent="end">
         <Button
           as={Link}
@@ -98,6 +100,7 @@ export const CircleAlbums: FC<CircleAlbums> = ({
           作成
         </Button>
       </HStack>
+      )}
       <Snacks snacks={snacks} />
       {currentAlbum ? (
         <AlbumCard

--- a/components/data-display/circle-threads.tsx
+++ b/components/data-display/circle-threads.tsx
@@ -172,31 +172,31 @@ export const CircleThreads: FC<CircleThreadsProps> = ({
               <Option value="isImportant">重要</Option>
             </MultiSelect>
             {isMember && (
-            <Menu>
-              <MenuButton
-                as={Button}
-                startIcon={<PlusIcon fontSize="2xl" />}
-                colorScheme="riverBlue"
-              >
-                作成
-              </MenuButton>
-              <MenuList>
-                <MenuItem
-                  icon={<BellPlusIcon fontSize="2xl" />}
-                  as={Link}
-                  href={`/circles/${circle?.id}/announcement/create`}
+              <Menu>
+                <MenuButton
+                  as={Button}
+                  startIcon={<PlusIcon fontSize="2xl" />}
+                  colorScheme="riverBlue"
                 >
-                  お知らせ
-                </MenuItem>
-                <MenuItem
-                  icon={<MessageCircleMoreIcon fontSize="2xl" />}
-                  as={Link}
-                  href={`/circles/${circle?.id}/thread/create`}
-                >
-                  スレッド
-                </MenuItem>
-              </MenuList>
-            </Menu>
+                  作成
+                </MenuButton>
+                <MenuList>
+                  <MenuItem
+                    icon={<BellPlusIcon fontSize="2xl" />}
+                    as={Link}
+                    href={`/circles/${circle?.id}/announcement/create`}
+                  >
+                    お知らせ
+                  </MenuItem>
+                  <MenuItem
+                    icon={<MessageCircleMoreIcon fontSize="2xl" />}
+                    as={Link}
+                    href={`/circles/${circle?.id}/thread/create`}
+                  >
+                    スレッド
+                  </MenuItem>
+                </MenuList>
+              </Menu>
             )}
           </HStack>
           {loading ? (

--- a/components/data-display/circle-threads.tsx
+++ b/components/data-display/circle-threads.tsx
@@ -171,6 +171,7 @@ export const CircleThreads: FC<CircleThreadsProps> = ({
               <Option value="announcement">お知らせ</Option>
               <Option value="isImportant">重要</Option>
             </MultiSelect>
+            {isMember && (
             <Menu>
               <MenuButton
                 as={Button}
@@ -196,6 +197,7 @@ export const CircleThreads: FC<CircleThreadsProps> = ({
                 </MenuItem>
               </MenuList>
             </Menu>
+            )}
           </HStack>
           {loading ? (
             <Center w="full" h="full">


### PR DESCRIPTION
Closes #261 <!-- 関連するイシュー番号があれば書く（例：#0） -->

## 概要

<!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->

## 変更点

所属していないサークルの活動日程・アルバム・掲示板では「追加」「作成」ボタンを表示しないように変更
<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

## 追加情報

<!-- その他で記述する情報があれば書いてください -->
講師から見た担当サークルも「追加」「作成」ボタンが表示されないようになった。。
あと講師担当サークルに「入会申請」が表示されるのは良い？
