### PR TITLE
fix: 全ての画面に最大固定幅指定

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,7 +39,7 @@ export default async function Home() {
   const calendarData = await getWeeklyActivities(user?.id || "")
 
   return (
-    <VStack w="full" h="fit-content" p="md">
+    <VStack w="full" maxW="9xl" h="fit-content" p="md" m="auto">
       <VStack>
         <Heading as="h2" size="lg">
           ようこそ！

--- a/components/disclosure/circle-detail-tabs.tsx
+++ b/components/disclosure/circle-detail-tabs.tsx
@@ -54,7 +54,7 @@ export const CircleDetailTabs: FC<CircleDetailTabsProps> = ({
   const { data } = membershipRequests
 
   return (
-    <Tabs index={tabIndex} w="full" h="full">
+    <Tabs index={tabIndex} w="full" maxW="9xl" h="full" m="auto">
       <TabList overflowX="auto" overflowY="hidden">
         <Tab
           flexShrink={0}

--- a/components/layouts/calendar.tsx
+++ b/components/layouts/calendar.tsx
@@ -41,7 +41,7 @@ export const CalendarPage: FC<CalendarPageProps> = ({ userId, events }) => {
   }, [currentMonth])
 
   return (
-    <Container p={4}>
+    <Container maxW="9xl" m="auto" p={4}>
       <Heading mb={4}>カレンダー</Heading>
       <Calendar
         month={currentMonth}

--- a/components/layouts/circle-detail-page.tsx
+++ b/components/layouts/circle-detail-page.tsx
@@ -80,6 +80,8 @@ export const CircleDetailPage: FC<{
         >
           <HStack
             w="full"
+            maxW="9xl"
+            m="auto"
             flexDirection={{
               base: `row`,
               md: `column`,

--- a/components/layouts/circles-page.tsx
+++ b/components/layouts/circles-page.tsx
@@ -55,7 +55,14 @@ export const CirclesPage: FC<CirclesPageProps> = ({ circles }) => {
 
   return (
     <>
-      <VStack ref={scrollRef} w="full" h="fit-content" gap={0}>
+      <VStack
+        ref={scrollRef}
+        w="full"
+        maxW="9xl"
+        h="fit-content"
+        gap={0}
+        m="auto"
+      >
         <VStack
           position="sticky"
           p="md"

--- a/components/layouts/notification-page.tsx
+++ b/components/layouts/notification-page.tsx
@@ -15,7 +15,7 @@ export const NotificationPage: FC<NotificationPageProps> = ({
   return (
     <PaginationList data={announcements}>
       {(currentAnnouncements) => (
-        <VStack w="full" h="full" gap="md">
+        <VStack w="full" h="full" gap="md" maxW="9xl" m="auto">
           <VStack>
             <Heading as="h2" size="lg">
               お知らせ


### PR DESCRIPTION
Related #262  <!-- 関連するイシュー番号があれば書く（例：#0） -->

## 概要

ラップトップよりも大きい画面幅の時にカードなどのサイズがおかしくなったりしたので、全ての画面に`maxW=9xl`を指定してそれ以上大きくならないようにした。

![image](https://github.com/user-attachments/assets/c601f5fd-ac9c-4ae3-8e9f-7b92a4b68c9b)

一応全部の画面でデフォルト時と、`Ctrl -`などで縮小した画面両方を確認してレイアウト崩れや修正漏れがないか確認してください。 @ymmyo5 


## 変更点

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

## 追加情報

<!-- その他で記述する情報があれば書いてください -->
