### PR TITLE
サークル一覧・検索画面の画面崩れ修正

### DIFF
--- a/components/data-display/custom-graph.tsx
+++ b/components/data-display/custom-graph.tsx
@@ -7,6 +7,7 @@ import {
   Center,
   Text,
   Card,
+  useBreakpointEffect,
 } from "@yamada-ui/react"
 import { useRef, useState } from "react"
 import { ForceGraph2D } from "react-force-graph"
@@ -51,11 +52,20 @@ const CustomGraph: FC<CustomGraphProps> = ({ query, data, loading }) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const [isDragging, setIsDragging] = useBoolean(false)
   const zoomLevelRef = useRef(1)
+  const breakPointRef = useRef(0)
 
   // onZoomハンドラ内ではuseRefの値を更新する
   const handleZoom = (event: { k: number }) => {
     zoomLevelRef.current = event.k
   }
+
+  useBreakpointEffect((breakpoint) => {
+    if (breakpoint === "sm") {
+      breakPointRef.current = 60
+    } else {
+      breakPointRef.current = 0
+    }
+  }, [])
 
   useSafeLayoutEffect(() => {
     data.nodes.forEach((node) => {
@@ -90,9 +100,13 @@ const CustomGraph: FC<CustomGraphProps> = ({ query, data, loading }) => {
   useSafeLayoutEffect(() => {
     const updateDimensions = () => {
       if (containerRef.current) {
+        const height =
+          window.innerHeight -
+          containerRef.current.offsetTop -
+          breakPointRef.current
         setDimensions({
           width: containerRef.current.offsetWidth,
-          height: containerRef.current.offsetHeight,
+          height: height,
         })
       }
     }
@@ -147,7 +161,7 @@ const CustomGraph: FC<CustomGraphProps> = ({ query, data, loading }) => {
           position="absolute"
           zIndex="beerus"
           rounded="full"
-          boxSize="md"
+          boxSize={{ base: "md", sm: "xs" }}
           bg="blackAlpha.100"
           flexDir="column"
           pointerEvents="none"
@@ -162,7 +176,7 @@ const CustomGraph: FC<CustomGraphProps> = ({ query, data, loading }) => {
           position="absolute"
           zIndex="beerus"
           rounded="full"
-          boxSize="md"
+          boxSize={{ base: "md", sm: "xs" }}
           bg="blackAlpha.100"
           flexDir="column"
           pointerEvents="none"

--- a/components/layouts/circles-page.tsx
+++ b/components/layouts/circles-page.tsx
@@ -152,8 +152,16 @@ export const CirclesPage: FC<CirclesPageProps> = ({ circles }) => {
           zIndex={1}
         >
           <HStack
-            alignItems={{ base: "center", sm: "start" }}
-            flexDir={{ sm: "column" }}
+            alignItems={{
+              base: "center",
+              md: mode !== 0 ? "start" : "center",
+              sm: "start",
+            }}
+            flexDir={{
+              base: "row",
+              md: mode !== 0 ? "column" : "row",
+              sm: "column",
+            }}
           >
             <Heading flex={1} as="h1" size="lg">
               サークル一覧
@@ -216,7 +224,8 @@ export const CirclesPage: FC<CirclesPageProps> = ({ circles }) => {
               _hover={{ transform: "scale(1.1)", transition: "0.5s" }}
               position="absolute"
               right={0}
-              top="-1"
+              top={{ base: "-1", sm: "1.5" }}
+              size={{ base: "md", sm: "xs" }}
             >
               サークル作成
             </Button>

--- a/components/media-and-icons/network-animation.tsx
+++ b/components/media-and-icons/network-animation.tsx
@@ -30,8 +30,8 @@ export default function NetWorkAnimation() {
   return (
     <ui.div
       pointerEvents="none"
-      height="150px"
-      width="150px"
+      height={{ base: "150px", sm: "100px" }}
+      width={{ base: "150px", sm: "100px" }}
       ref={animationRef}
     ></ui.div>
   )

--- a/components/media-and-icons/robot-animation.tsx
+++ b/components/media-and-icons/robot-animation.tsx
@@ -30,8 +30,8 @@ export default function RobotAnimation() {
   return (
     <ui.div
       pointerEvents="none"
-      height="250px"
-      width="250px"
+      height={{ base: "250px", sm: "150px" }}
+      width={{ base: "250px", sm: "150px" }}
       ref={animationRef}
     ></ui.div>
   )


### PR DESCRIPTION
Closes # <!-- 関連するイシュー番号があれば書く（例：#0） -->

## 概要

<!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->

以下のように画面が小さいとボタンが重なったり、アニメーションの円が大きすぎてはみ出てしまうのを修正

<img width="178" alt="image" src="https://github.com/user-attachments/assets/b296e50c-0ceb-426d-a642-374f3b3262cc" />
<img width="180" alt="image" src="https://github.com/user-attachments/assets/5f13f2ef-92fa-4e04-9988-a5bc9232f68f" />


## 変更点

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

## 追加情報

<!-- その他で記述する情報があれば書いてください -->
