### PR TITLE
fix: `mdast-util-gfm-autolink-literal`のバージョンを固定

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
   "pnpm": {
     "overrides": {
       "ws": "^8.17.1",
-      "got": "^11.8.5"
+      "got": "^11.8.5",
+      "mdast-util-gfm-autolink-literal": "2.0.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   ws: ^8.17.1
   got: ^11.8.5
+  mdast-util-gfm-autolink-literal: 2.0.0
 
 importers:
 
@@ -59,7 +60,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-force-graph:
         specifier: ^1.46.0
-        version: 1.46.0(react@18.3.1)(three@0.172.0)
+        version: 1.46.0(react@18.3.1)(three@0.164.1)
       react-hook-form:
         specifier: ^7.54.2
         version: 7.54.2(react@18.3.1)
@@ -4964,8 +4965,8 @@ packages:
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
 
-  mdast-util-gfm-autolink-literal@2.0.1:
-    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+  mdast-util-gfm-autolink-literal@2.0.0:
+    resolution: {integrity: sha512-FyzMsduZZHSc3i0Px3PQcBT4WJY/X/RCtEJKuybiC6sjPqLv7h1yqAkmILZtuxMSsUyaLUWNp71+vQH2zqp5cg==}
 
   mdast-util-gfm-footnote@2.0.0:
     resolution: {integrity: sha512-5jOT2boTSVkMnQ7LTrd6n/18kqwjmuYqo7JUPe+tRCY6O7dAuTFMtTPauYYrMPpox9hlN0uOx/FL8XvEfG9/mQ==}
@@ -6947,19 +6948,19 @@ packages:
 
 snapshots:
 
-  3d-force-graph-ar@1.9.3(three@0.172.0):
+  3d-force-graph-ar@1.9.3(three@0.164.1):
     dependencies:
-      aframe-forcegraph-component: 3.1.0(three@0.172.0)
+      aframe-forcegraph-component: 3.1.0(three@0.164.1)
       kapsule: 1.16.0
     transitivePeerDependencies:
       - three
 
-  3d-force-graph-vr@2.4.3(three@0.172.0):
+  3d-force-graph-vr@2.4.3(three@0.164.1):
     dependencies:
       accessor-fn: 1.5.1
       aframe: 1.6.0
       aframe-extras: 7.5.4
-      aframe-forcegraph-component: 3.1.0(three@0.172.0)
+      aframe-forcegraph-component: 3.1.0(three@0.164.1)
       kapsule: 1.16.0
       polished: 4.3.1
     transitivePeerDependencies:
@@ -10573,10 +10574,10 @@ snapshots:
       three: 0.164.1
       three-pathfinding: 1.3.0(three@0.164.1)
 
-  aframe-forcegraph-component@3.1.0(three@0.172.0):
+  aframe-forcegraph-component@3.1.0(three@0.164.1):
     dependencies:
       accessor-fn: 1.5.1
-      three-forcegraph: 1.42.12(three@0.172.0)
+      three-forcegraph: 1.42.12(three@0.164.1)
     transitivePeerDependencies:
       - three
 
@@ -13194,7 +13195,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-autolink-literal@2.0.1:
+  mdast-util-gfm-autolink-literal@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       ccount: 2.0.1
@@ -13242,7 +13243,7 @@ snapshots:
   mdast-util-gfm@3.0.0:
     dependencies:
       mdast-util-from-markdown: 2.0.2
-      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-autolink-literal: 2.0.0
       mdast-util-gfm-footnote: 2.0.0
       mdast-util-gfm-strikethrough: 2.0.0
       mdast-util-gfm-table: 2.0.0
@@ -14351,11 +14352,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.18
 
-  react-force-graph@1.46.0(react@18.3.1)(three@0.172.0):
+  react-force-graph@1.46.0(react@18.3.1)(three@0.164.1):
     dependencies:
       3d-force-graph: 1.76.0
-      3d-force-graph-ar: 1.9.3(three@0.172.0)
-      3d-force-graph-vr: 2.4.3(three@0.172.0)
+      3d-force-graph-ar: 1.9.3(three@0.164.1)
+      3d-force-graph-vr: 2.4.3(three@0.164.1)
       force-graph: 1.49.0
       prop-types: 15.8.1
       react: 18.3.1
@@ -15079,6 +15080,20 @@ snapshots:
       layout-bmfont-text: 1.3.4
       nice-color-palettes: 3.0.0
       quad-indices: 2.0.1
+
+  three-forcegraph@1.42.12(three@0.164.1):
+    dependencies:
+      accessor-fn: 1.5.1
+      d3-array: 3.2.4
+      d3-force-3d: 3.0.5
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      data-bind-mapper: 1.0.1
+      kapsule: 1.16.0
+      ngraph.forcelayout: 3.3.1
+      ngraph.graph: 20.0.1
+      three: 0.164.1
+      tinycolor2: 1.6.0
 
   three-forcegraph@1.42.12(three@0.172.0):
     dependencies:


### PR DESCRIPTION
Closes # <!-- 関連するイシュー番号があれば書く（例：#0） -->

## 概要

<!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
プロフィールのページで古いiOSでのみブラウザがクラッシュするので中身のライブラリのバージョンを下げた

## 変更点

<!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

## 追加情報

<!-- その他で記述する情報があれば書いてください -->
